### PR TITLE
feat: allow custom JSON encoders/decoders

### DIFF
--- a/Papyrus.xcodeproj/project.pbxproj
+++ b/Papyrus.xcodeproj/project.pbxproj
@@ -400,6 +400,7 @@
 				A4C9E6A12589D73D00476A7E /* Sources */,
 				A4C9E6A22589D73D00476A7E /* Frameworks */,
 				A4C9E6A32589D73D00476A7E /* Resources */,
+				91E20C9227AEE1BC00D9AC4B /* SwiftLint */,
 			);
 			buildRules = (
 			);
@@ -493,6 +494,27 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
+
+/* Begin PBXShellScriptBuildPhase section */
+		91E20C9227AEE1BC00D9AC4B /* SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = SwiftLint;
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if which swiftlint >/dev/null; then\n    swiftlint --fix && swiftlint --strict\nelse\n    echo \"warning: SwiftLint not installed, download from https://github.com/realm/SwiftLint\"\nfi\n";
+		};
+/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		A47AD40826A577A70075439D /* Sources */ = {

--- a/Papyrus.xcodeproj/project.pbxproj
+++ b/Papyrus.xcodeproj/project.pbxproj
@@ -576,9 +576,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CF43K35J9C;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -601,9 +602,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++17";
+				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = CF43K35J9C;
+				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -748,14 +750,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Papyrus/Supporting Files/Info.plist";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -765,6 +768,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reddavis.Papyrus;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphoneos appletvos watchos appletvsimulator iphonesimulator watchsimulator";
@@ -777,14 +781,15 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = "";
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				INFOPLIST_FILE = "Papyrus/Supporting Files/Info.plist";
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = "";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -794,6 +799,7 @@
 				MACOSX_DEPLOYMENT_TARGET = 12.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.reddavis.Papyrus;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = "";
 				SKIP_INSTALL = YES;
 				SUPPORTED_PLATFORMS = "macosx iphoneos appletvos watchos appletvsimulator iphonesimulator watchsimulator";

--- a/Papyrus.xcodeproj/project.pbxproj
+++ b/Papyrus.xcodeproj/project.pbxproj
@@ -603,7 +603,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -629,7 +629,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Papyrus/Source/Observers/ObjectCollectionObserver.swift
+++ b/Papyrus/Source/Observers/ObjectCollectionObserver.swift
@@ -4,7 +4,8 @@ import Foundation
 final class ObjectCollectionObserver<Output: Papyrus> {
     private let fileManager = FileManager.default
     private let url: URL
-    
+    private let decoder: JSONDecoder
+
     private var directoryObserver: DirectoryObserver?
     private let onChange: (_ objects: [Output]) -> Void
     
@@ -12,9 +13,11 @@ final class ObjectCollectionObserver<Output: Papyrus> {
     
     init(
         url: URL,
+        decoder: JSONDecoder = JSONDecoder(),
         onChange: @escaping (_ objects: [Output]) -> Void
     ) {
         self.url = url
+        self.decoder = decoder
         self.onChange = onChange
     }
     
@@ -44,7 +47,6 @@ final class ObjectCollectionObserver<Output: Papyrus> {
     
     private func fetchObjects() -> [Output] {
         guard let directoryNames = try? self.fileManager.contentsOfDirectory(atPath: self.url.path) else { return [] }
-        let decoder = JSONDecoder()
         
         return directoryNames
             .map { self.url.appendingPathComponent($0) }

--- a/Papyrus/Source/Observers/ObjectObserver.swift
+++ b/Papyrus/Source/Observers/ObjectObserver.swift
@@ -6,6 +6,7 @@ final class ObjectObserver<Output: Papyrus> {
     private let filename: String
     private let directoryURL: URL
     private var previousFetch: Result<Output, PapyrusStore.QueryError>?
+    private let decoder: JSONDecoder
     
     private var directoryObserver: DirectoryObserver?
     private let onChange: (_ result: Result<Output, PapyrusStore.QueryError>) -> Void
@@ -15,10 +16,12 @@ final class ObjectObserver<Output: Papyrus> {
     init(
         filename: String,
         directoryURL: URL,
+        decoder: JSONDecoder = JSONDecoder(),
         onChange: @escaping (_ result: Result<Output, PapyrusStore.QueryError>) -> Void
     ) {
         self.filename = filename
         self.directoryURL = directoryURL
+        self.decoder = decoder
         self.onChange = onChange
     }
     
@@ -75,7 +78,7 @@ final class ObjectObserver<Output: Papyrus> {
         
         do {
             let data = try Data(contentsOf: fileURL)
-            return try JSONDecoder().decode(Output.self, from: data)
+            return try decoder.decode(Output.self, from: data)
         } catch {
             throw PapyrusStore.QueryError.invalidSchema(details: error)
         }

--- a/Papyrus/Source/PapyrusStore.swift
+++ b/Papyrus/Source/PapyrusStore.swift
@@ -129,7 +129,7 @@ public extension PapyrusStore {
         
         let now = Date()
         touchedDirectories.forEach {
-            try? self.fileManager.setAttributes([.modificationDate : now], ofItemAtPath: $0.path)
+            try? self.fileManager.setAttributes([.modificationDate: now], ofItemAtPath: $0.path)
         }
     }
     
@@ -197,25 +197,25 @@ public extension PapyrusStore {
     ///   - id: The `id` of the object to be deleted.
     ///   - type: The `type` of the object to be deleted.
     func delete<T: Papyrus, ID: LosslessStringConvertible & Hashable>(id: ID, of type: T.Type) async {
-        await self.delete(objectIdentifiers: [id : type])
+        await self.delete(objectIdentifiers: [id: type])
     }
 
     /// Deletes an object from the store.
     /// - Parameter object: The object to delete.
     func delete<T: Papyrus>(_ object: T) async {
-        await self.delete(objectIdentifiers: [object.id : T.self])
+        await self.delete(objectIdentifiers: [object.id: T.self])
     }
     
     /// Deletes an array of objects.
     /// - Parameter objects: An array of objects to delete.
     func delete<T: Papyrus, ID>(objects: [T]) async where ID == T.ID {
-        let identifiers = objects.reduce(into: [ID : T.Type]()) {
+        let identifiers = objects.reduce(into: [ID: T.Type]()) {
             $0[$1.id] = T.self
         }
         await self.delete(objectIdentifiers: identifiers)
     }
     
-    private func delete<ID: LosslessStringConvertible, T: Papyrus>(objectIdentifiers: [ID : T.Type]) async {
+    private func delete<ID: LosslessStringConvertible, T: Papyrus>(objectIdentifiers: [ID: T.Type]) async {
         await withTaskGroup(of: Void.self, body: { group in
             let touchedDirectories = Set(objectIdentifiers.map {
                 self.directoryURL(for: $0.value)
@@ -235,7 +235,7 @@ public extension PapyrusStore {
             let now = Date()
             for url in touchedDirectories {
                 group.addTask {
-                    try? self.fileManager.setAttributes([.modificationDate : now], ofItemAtPath: url.path)
+                    try? self.fileManager.setAttributes([.modificationDate: now], ofItemAtPath: url.path)
                 }
             }
         })

--- a/Papyrus/Source/PapyrusStore.swift
+++ b/Papyrus/Source/PapyrusStore.swift
@@ -20,19 +20,27 @@ public final class PapyrusStore {
     private let url: URL
     private let logger: Logger
     
-    private let encoder = JSONEncoder()
-    private let decoder = JSONDecoder()
+    private let encoder: JSONEncoder
+    private let decoder: JSONDecoder
     
     // MARK: Initialization
     
     /// Initialize a new `PapyrusStore` instance persisted at the provided `URL`.
     /// - Parameter url: The `URL` to persist data to.
-    public init(url: URL) {
+    /// - Parameter encoder: A custom JSON encoder for encoding persisted data.
+    /// Defaults to the standard JSON encoder.
+    /// - Parameter decoder: A custom JSON decoder for decoding persisted data.
+    /// Defaults to the standard JSON decoder.
+    public init(url: URL,
+                encoder: JSONEncoder = JSONEncoder(),
+                decoder: JSONDecoder = JSONDecoder()) {
         self.url = url
         self.logger = Logger(
             subsystem: "com.reddavis.PapyrusStore",
             category: "PapyrusStore"
         )
+        self.encoder = encoder
+        self.decoder = decoder
         self.setupDataDirectory()
     }
     

--- a/Papyrus/Source/Publishers/Collection/CollectionObserverSubscription.swift
+++ b/Papyrus/Source/Publishers/Collection/CollectionObserverSubscription.swift
@@ -10,12 +10,14 @@ where T.Input == [Output] {
     private var subscriber: T?
     private var demand: Subscribers.Demand = .none
     private var observer: DirectoryObserver?
+    private let decoder: JSONDecoder
     
     // MARK: Initialization
     
-    init(directoryURL: URL, subscriber: T) {
+    init(directoryURL: URL, subscriber: T, decoder: JSONDecoder = JSONDecoder()) {
         self.directoryURL = directoryURL
         self.subscriber = subscriber
+        self.decoder = decoder
     }
     
     // MARK: Subscriber
@@ -54,7 +56,6 @@ where T.Input == [Output] {
     
     private func fetchModels() -> [Output] {
         guard let directoryNames = try? self.fileManager.contentsOfDirectory(atPath: self.directoryURL.path) else { return [] }
-        let decoder = JSONDecoder()
         
         return directoryNames
             .map { self.directoryURL.appendingPathComponent($0) }

--- a/Papyrus/Source/Queries/CollectionQuery.swift
+++ b/Papyrus/Source/Queries/CollectionQuery.swift
@@ -12,11 +12,13 @@ public class CollectionQuery<T> where T: Papyrus {
     private let directoryURL: URL
     private var filter: OnFilter?
     private var sort: OnSort?
+    private let decoder: JSONDecoder
     
     // MARK: Initialization
     
-    init(directoryURL: URL) {
+    init(directoryURL: URL, decoder: JSONDecoder = JSONDecoder()) {
         self.directoryURL = directoryURL
+        self.decoder = decoder
     }
     
     // MARK: API
@@ -26,7 +28,6 @@ public class CollectionQuery<T> where T: Papyrus {
     /// - Returns: The results of the query.
     public func execute() async -> [T] {
         guard let directoryNames = try? self.fileManager.contentsOfDirectory(atPath: self.directoryURL.path) else { return [] }
-        let decoder = JSONDecoder()
         
         do {
             return try directoryNames

--- a/Papyrus/Source/Queries/ObjectQuery.swift
+++ b/Papyrus/Source/Queries/ObjectQuery.swift
@@ -9,15 +9,18 @@ public class ObjectQuery<T: Papyrus> {
     private let fileManager = FileManager.default
     private let filename: String
     private let directoryURL: URL
+    private let decoder: JSONDecoder
     
     // MARK: Initialization
     
     init<ID: LosslessStringConvertible>(
         id: ID,
-        directoryURL: URL
+        directoryURL: URL,
+        decoder: JSONDecoder = JSONDecoder()
     ) {
         self.filename = String(id)
         self.directoryURL = directoryURL
+        self.decoder = decoder
     }
     
     // MARK: API
@@ -31,7 +34,7 @@ public class ObjectQuery<T: Papyrus> {
         
         do {
             let data = try Data(contentsOf: fileURL)
-            return try JSONDecoder().decode(T.self, from: data)
+            return try decoder.decode(T.self, from: data)
         } catch {
             // Cached data is using an old schema.
             throw PapyrusStore.QueryError.invalidSchema(details: error)

--- a/PapyrusTests/Source/Tests/CollectionObserverPublisherTests.swift
+++ b/PapyrusTests/Source/Tests/CollectionObserverPublisherTests.swift
@@ -2,6 +2,7 @@ import Combine
 import XCTest
 @testable import Papyrus
 
+// swiftlint:disable implicitly_unwrapped_optional
 
 final class CollectionObserverPublisherTests: XCTestCase {
     private var storeDirectory: URL!
@@ -97,7 +98,7 @@ final class CollectionObserverPublisherTests: XCTestCase {
             .store(in: &self.cancellables)
         
         try FileManager.default.setAttributes(
-            [.modificationDate : Date()],
+            [.modificationDate: Date()],
             ofItemAtPath: self.storeDirectory.path
         )
         

--- a/PapyrusTests/Source/Tests/CollectionQueryTests.swift
+++ b/PapyrusTests/Source/Tests/CollectionQueryTests.swift
@@ -2,6 +2,7 @@ import Combine
 import XCTest
 @testable import Papyrus
 
+// swiftlint:disable implicitly_unwrapped_optional
 
 final class CollectionQueryTests: XCTestCase {
     private var storeDirectory: URL!

--- a/PapyrusTests/Source/Tests/DirectoryObserverTests.swift
+++ b/PapyrusTests/Source/Tests/DirectoryObserverTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Papyrus
 
+// swiftlint:disable implicitly_unwrapped_optional
 
 class DirectoryObserverTests: XCTestCase {
     private var directory: URL!
@@ -38,7 +39,7 @@ class DirectoryObserverTests: XCTestCase {
         XCTAssert(self.fileManager.fileExists(atPath: self.directory.path))
         
         try self.fileManager.setAttributes(
-            [.modificationDate : Date.now],
+            [.modificationDate: Date.now],
             ofItemAtPath: self.directory.path
         )
         

--- a/PapyrusTests/Source/Tests/ObjectCollectionObserverTests.swift
+++ b/PapyrusTests/Source/Tests/ObjectCollectionObserverTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Papyrus
 
+// swiftlint:disable implicitly_unwrapped_optional
 
 class ObjectCollectionObserverTests: XCTestCase {
     private var temporaryDirectoryURL: URL!
@@ -55,7 +56,7 @@ class ObjectCollectionObserverTests: XCTestCase {
         
         // Write object
         try self.fileManager.setAttributes(
-            [.modificationDate : Date.now],
+            [.modificationDate: Date.now],
             ofItemAtPath: self.directory.path
         )
         

--- a/PapyrusTests/Source/Tests/ObjectFileObserverTests.swift
+++ b/PapyrusTests/Source/Tests/ObjectFileObserverTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Papyrus
 
+// swiftlint:disable implicitly_unwrapped_optional
 
 class ObjectObserverTests: XCTestCase {
     private var temporaryDirectoryURL: URL!
@@ -128,7 +129,7 @@ class ObjectObserverTests: XCTestCase {
 fileprivate extension ObjectObserverTests {
     func markDirectoryAsUpdated(_ url: URL, date: Date = .now) throws {
         try self.fileManager.setAttributes(
-            [.modificationDate : date],
+            [.modificationDate: date],
             ofItemAtPath: url.path
         )
     }

--- a/PapyrusTests/Source/Tests/ObjectObserverPublisherTests.swift
+++ b/PapyrusTests/Source/Tests/ObjectObserverPublisherTests.swift
@@ -2,6 +2,7 @@ import Combine
 import XCTest
 @testable import Papyrus
 
+// swiftlint:disable implicitly_unwrapped_optional
 
 final class ObjectObserverPublisherTests: XCTestCase {
     private var id: String!
@@ -178,7 +179,7 @@ final class ObjectObserverPublisherTests: XCTestCase {
 extension ObjectObserverPublisherTests {
     func updateDirectoryModificationDate(directorURL: URL) throws {
         try FileManager.default.setAttributes(
-            [.modificationDate : Date()],
+            [.modificationDate: Date()],
             ofItemAtPath: directorURL.path
         )
     }

--- a/PapyrusTests/Source/Tests/ObjectQueryTests.swift
+++ b/PapyrusTests/Source/Tests/ObjectQueryTests.swift
@@ -2,6 +2,7 @@ import Combine
 import XCTest
 @testable import Papyrus
 
+// swiftlint:disable implicitly_unwrapped_optional
 
 final class ObjectQueryTests: XCTestCase {
     private let fileManager = FileManager.default
@@ -91,7 +92,7 @@ final class ObjectQueryTests: XCTestCase {
 extension ObjectQueryTests {
     func updateDirectoryModificationDate(directoryURL: URL) throws {
         try FileManager.default.setAttributes(
-            [.modificationDate : Date.now],
+            [.modificationDate: Date.now],
             ofItemAtPath: directoryURL.path
         )
     }

--- a/PapyrusTests/Source/Tests/PapyrusStoreTests.swift
+++ b/PapyrusTests/Source/Tests/PapyrusStoreTests.swift
@@ -2,6 +2,7 @@ import Combine
 import XCTest
 @testable import Papyrus
 
+// swiftlint:disable implicitly_unwrapped_optional
 
 final class PapyrusStoreTests: XCTestCase {
     private let fileManager = FileManager.default

--- a/PerformanceTests/PerformanceTests.swift
+++ b/PerformanceTests/PerformanceTests.swift
@@ -67,6 +67,8 @@ class PerformanceTests: XCTestCase {
         }
     }
     
+
+    #if !os(iOS)
     func testObjectDeletion() async throws {
         let objects = (0..<1000).map { _ in
             ExampleB(id: UUID().uuidString)
@@ -86,4 +88,5 @@ class PerformanceTests: XCTestCase {
             group.wait()
         }
     }
+    #endif
 }

--- a/PerformanceTests/PerformanceTests.swift
+++ b/PerformanceTests/PerformanceTests.swift
@@ -4,7 +4,9 @@ import XCTest
 
 class PerformanceTests: XCTestCase {
     private let fileManager = FileManager.default
+    // swiftlint:disable:next implicitly_unwrapped_optional
     private var store: PapyrusStore!
+    // swiftlint:disable:next implicitly_unwrapped_optional
     private var directory: URL!
     
     // MARK: Setup


### PR DESCRIPTION
Currently the framework only uses the standard JSON encoder/decoder for persisting data.

These updates allows a developer to supply their own encoders/decoders if needed for persisting while leaving the framework intact.

- [x] Allow custom encoder/decoder
- [x] Fix Xcode build for general building
- [x] Run SwiftLint during build so developers don't have to wait for CI. Also builds using `--fix` to allow SwiftLint to fix spacing and other minor issues